### PR TITLE
Integrating tcrosser library into SpikeSorter; cleanup

### DIFF
--- a/Plugins/SpikeSorter/CMakeLists.txt
+++ b/Plugins/SpikeSorter/CMakeLists.txt
@@ -15,6 +15,28 @@ add_sources(${PLUGIN_NAME}
 	SpikeSorterCanvas.cpp
 	SpikeSorterCanvas.h
 	)
-	
+
+
+# ===== External Dependency: TCrosser
+configure_file(CMakeLists.txt.in.tcrosser tcrosser-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tcrosser-download )
+if(result)
+	message(FATAL_ERROR "CMake step for tcrosser failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tcrosser-download )
+if(result)
+	message(FATAL_ERROR "Build step for tcrosser failed: ${result}")
+endif()
+set(BUILD_TCROSSER ON)
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/tcrosser-src
+		${CMAKE_CURRENT_BINARY_DIR}/tcrosser-build
+		EXCLUDE_FROM_ALL)
+
 #optional: create IDE groups
 #plugin_create_filters()
+
+target_link_libraries(${PLUGIN_NAME} tcrosser)

--- a/Plugins/SpikeSorter/CMakeLists.txt.in.tcrosser
+++ b/Plugins/SpikeSorter/CMakeLists.txt.in.tcrosser
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(tcrosser-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(tcrosser
+  GIT_REPOSITORY    git@github.com:carmenalab/c.git
+  GIT_TAG           botros/cmake
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/tcrosser-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/tcrosser-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/Plugins/SpikeSorter/SpikeSorterCanvas.cpp
+++ b/Plugins/SpikeSorter/SpikeSorterCanvas.cpp
@@ -694,7 +694,7 @@ void SpikeHistogramPlot::initAxes(std::vector<float> scales)
     for (int i = 0; i < nWaveAx; i++)
     {
         WaveformAxes* wAx = new WaveformAxes(this,processor, electrodeID, i);
-        wAx->setDetectorThreshold(processor->getActiveElectrode()->thresholds[i]);
+        wAx->setDetectorThreshold(processor->getActiveElectrode()->get_threshold(i));
         wAxes.add(wAx);
         addAndMakeVisible(wAx);
         ranges.add(scales[i]);
@@ -1487,7 +1487,7 @@ void WaveformAxes::mouseDrag(const MouseEvent& event)
              }
          }
         else{
-            processor->getActiveElectrode()->thresholds[channel] = displayThresholdLevel;
+            processor->getActiveElectrode()->set_threshold(channel, displayThresholdLevel);
         }
 
         SpikeSorterEditor* edt = (SpikeSorterEditor*) processor->getEditor();

--- a/Plugins/SpikeSorter/SpikeSorterEditor.cpp
+++ b/Plugins/SpikeSorter/SpikeSorterEditor.cpp
@@ -499,7 +499,7 @@ void SpikeSorterEditor::buttonEvent(Button* button)
 
         for (int i = 0; i < e->numChannels; i++)
         {
-            int channelNum = e->channels[i];
+            int channelNum = e->get_channel(i);
             channelSelector->setAudioStatus(channelNum, audioMonitorButton->getToggleState());
 
         }
@@ -607,8 +607,8 @@ void SpikeSorterEditor::refreshElectrodeList(int selected)
 
         if (processor->getAutoDacAssignmentStatus())
         {
-            processor->assignDACtoChannel(0, e->channels[0]);
-            processor->assignDACtoChannel(1, e->channels[0]);
+            processor->assignDACtoChannel(0, e->get_channel(0));
+            processor->assignDACtoChannel(1, e->get_channel(0));
         }
      /*   Array<int> dacAssignmentToChannels = processor->getDACassignments();
         // search for channel[0]. If found, set the combo box accordingly...
@@ -746,8 +746,8 @@ void SpikeSorterEditor::comboBoxChanged(ComboBox* comboBox)
 
             if (processor->getAutoDacAssignmentStatus())
             {
-                processor->assignDACtoChannel(0, e->channels[0]);
-                processor->assignDACtoChannel(1, e->channels[0]);
+                processor->assignDACtoChannel(0, e->get_channel(0));
+                processor->assignDACtoChannel(1, e->get_channel(0));
             }
          /*   Array<int> dacAssignmentToChannels = processor->getDACassignments();
             // search for channel[0]. If found, set the combo box accordingly...


### PR DESCRIPTION
Integrating the tcrosser library (carmenalab/tcrosser on git) into the
existing SpikeSorter plugin. This does away with the (rudimentary)
threshold crossing done in the SpikeSorter, which was somewhat
incomplete: it only supported local minima/maxima alignment (as opposed
to global), did not properly wait for enough samples to gather to form a
post-peak window, support a dead-time between detected threshold
crossings, etc.

Aside from the direct integration of tcrosser into the library, there's
some cleanup of dead code included:
- Abstracting Electrode getter/setters on thresholds/channels/active
flags, to ensure things stay in sync with the threshold crossing
detector.
- Removing any mention of "overflow" buffers, unneeded now.