### PR TITLE
Allowing for an HTTP server to control processor parameters

### DIFF
--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -49,6 +49,7 @@ static inline File getSavedStateDirectory() {
 			false);   // useBottomCornerRisizer -- doesn't work very well
 
 	shouldReloadOnStartup = false;
+	shouldEnableHttpServer = false;
 
 	// Create ProcessorGraph and AudioComponent, and connect them.
 	// Callbacks will be set by the play button in the control panel
@@ -93,8 +94,11 @@ static inline File getSavedStateDirectory() {
 		ui->getEditorViewport()->loadState(file);
 	}
 
-
-
+	if (shouldEnableHttpServer) {
+		processorGraph->enableHttpServer();
+	} else {
+		processorGraph->disableHttpServer();
+	}
 }
 
 MainWindow::~MainWindow()
@@ -152,6 +156,7 @@ void MainWindow::saveWindowBounds()
 
 	xml->setAttribute("version", JUCEApplication::getInstance()->getApplicationVersion());
 	xml->setAttribute("shouldReloadOnStartup", shouldReloadOnStartup);
+	xml->setAttribute("shouldEnableHttpServer", shouldEnableHttpServer);
 
 	XmlElement* bounds = new XmlElement("BOUNDS");
 	bounds->setAttribute("x",getScreenX());
@@ -211,6 +216,7 @@ void MainWindow::loadWindowBounds()
 		String description;
 
 		shouldReloadOnStartup = xml->getBoolAttribute("shouldReloadOnStartup", false);
+        shouldEnableHttpServer = xml->getBoolAttribute("shouldEnableHttpServer", false);
 
 		forEachXmlChildElement(*xml, e)
 		{

--- a/Source/MainWindow.h
+++ b/Source/MainWindow.h
@@ -62,6 +62,9 @@ public:
     /** Determines whether the last used configuration reloads upon startup. */
     bool shouldReloadOnStartup;
 
+    /** Determines whether the HTTP API server should be enabled. */
+    bool shouldEnableHttpServer;
+
 	void shutDownGUI();
 
 private:

--- a/Source/Processors/Parameter/Parameter.cpp
+++ b/Source/Processors/Parameter/Parameter.cpp
@@ -239,6 +239,10 @@ void Parameter::setDescription (const String& description)
     m_descriptionValueObject = description;
 }
 
+int Parameter::getNumChannels() const
+{
+    return m_values.size();
+}
 
 void Parameter::setValue (float value, int channel)
 {
@@ -261,6 +265,31 @@ void Parameter::setValue (float value, int channel)
     {
         m_values.set (channel, value);
     }
+}
+
+bool Parameter::setValue(const var &val, int chan) {
+    if (isBoolean()) {
+        if (!val.isBool()) {
+            return false;
+        }
+    } else if (isContinuous()) {
+        if (!val.isDouble()) {
+            return false;
+        }
+    } else if (isDiscrete()) {
+        if (!val.isInt()) {
+            return false;
+        }
+    } else if (isNumerical()) {
+        if (!val.isDouble()) {
+            return false;
+        }
+    } else {
+        // Unhandled type?
+        jassertfalse;
+    }
+    m_values.set(chan, val);
+    return true;
 }
 
 

--- a/Source/Processors/Parameter/Parameter.h
+++ b/Source/Processors/Parameter/Parameter.h
@@ -138,6 +138,9 @@ public:
     /** Returns the desired bounds for editor if parameter has it. */
     const juce::Rectangle<int>& getEditorDesiredBounds() const noexcept;
 
+    /** Gets the channels with values set for this parameter. */
+    int getNumChannels() const;
+
     /** Sets the name of a parameter. */
     void setName (const String& newName);
 
@@ -146,6 +149,9 @@ public:
 
     /** Sets the value of a parameter for a given channel.*/
     void setValue (float val, int chan);
+
+    /** Sets the value of a parameter for a given channel. Returns whether the value was actually set. */
+    bool setValue(const var &val, int chan);
 
     /** Sets the possible values. It makes sense only for discrete parameters. */
     void setPossibleValues (Array<var> possibleValues);

--- a/Source/Processors/ProcessorGraph/CMakeLists.txt
+++ b/Source/Processors/ProcessorGraph/CMakeLists.txt
@@ -1,11 +1,53 @@
 #Open Ephys GUI direcroty-specific file
 
 #add files in this folder
-add_sources(open-ephys 
+add_sources(open-ephys
 	ProcessorGraph.cpp
 	ProcessorGraph.h
+	ProcessorGraphHttpServer.h
 )
 
 #add nested directories
 
+# ===== External Dependency: cpp-httplib
+cmake_policy(SET CMP0079 NEW)
+set(HTTPLIB_USE_BROTLI_IF_AVAILABLE OFF)
+set(HTTPLIB_USE_ZLIB_IF_AVAILABLE OFF)
 
+configure_file(CMakeLists.txt.in.httplib httplib-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/httplib-download )
+if(result)
+	message(FATAL_ERROR "CMake step for httplib failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/httplib-download )
+if(result)
+	message(FATAL_ERROR "Build step for httplib failed: ${result}")
+endif()
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/httplib-src
+		${CMAKE_CURRENT_BINARY_DIR}/httplib-build
+		EXCLUDE_FROM_ALL)
+
+# ===== External Dependency: json
+configure_file(CMakeLists.txt.in.json json-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/json-download )
+if(result)
+	message(FATAL_ERROR "CMake step for json failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+		RESULT_VARIABLE result
+		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/json-download )
+if(result)
+	message(FATAL_ERROR "Build step for json failed: ${result}")
+endif()
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/json-src
+		${CMAKE_CURRENT_BINARY_DIR}/json-build
+		EXCLUDE_FROM_ALL)
+
+
+target_link_libraries(open-ephys httplib::httplib nlohmann_json::nlohmann_json)

--- a/Source/Processors/ProcessorGraph/CMakeLists.txt.in.httplib
+++ b/Source/Processors/ProcessorGraph/CMakeLists.txt.in.httplib
@@ -1,0 +1,15 @@
+project(httplib-download NONE)
+
+cmake_minimum_required(VERSION 3.17)
+
+include(ExternalProject)
+ExternalProject_Add(httplib
+  GIT_REPOSITORY    https://github.com/yhirose/cpp-httplib.git
+  GIT_TAG           v0.7.7
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/httplib-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/httplib-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/Source/Processors/ProcessorGraph/CMakeLists.txt.in.json
+++ b/Source/Processors/ProcessorGraph/CMakeLists.txt.in.json
@@ -1,0 +1,15 @@
+project(json-download NONE)
+
+cmake_minimum_required(VERSION 3.17)
+
+include(ExternalProject)
+ExternalProject_Add(json
+  GIT_REPOSITORY    https://github.com/nlohmann/json.git
+  GIT_TAG           v3.9.1
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/json-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/json-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -39,6 +39,7 @@
 #include "../../UI/TimestampSourceSelection.h"
 
 #include "../ProcessorManager/ProcessorManager.h"
+#include "ProcessorGraphHttpServer.h"
 
 ProcessorGraph::ProcessorGraph() : currentNodeId(100)
 {
@@ -49,12 +50,22 @@ ProcessorGraph::ProcessorGraph() : currentNodeId(100)
                          2, // number of outputs
                          44100.0, // sampleRate
                          1024);    // blockSize
-
+    http_server_thread = std::make_unique<ProcessorGraphHttpServer>(this);
 }
 
 ProcessorGraph::~ProcessorGraph()
 {
+    if (http_server_thread) {
+        http_server_thread->stop();
+    }
+}
 
+void ProcessorGraph::enableHttpServer() {
+    http_server_thread->start();
+}
+
+void ProcessorGraph::disableHttpServer() {
+    http_server_thread->stop();
 }
 
 void ProcessorGraph::createDefaultNodes()
@@ -194,7 +205,7 @@ void ProcessorGraph::restoreParameters()
 
 }
 
-Array<GenericProcessor*> ProcessorGraph::getListOfProcessors()
+Array<GenericProcessor*> ProcessorGraph::getListOfProcessors() const
 {
 
     Array<GenericProcessor*> a;

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.h
@@ -49,6 +49,8 @@ class TimestampSourceSelectionWindow;
        AudioNode, Configuration, MessageCenter
 */
 
+class ProcessorGraphHttpServer;
+
 class ProcessorGraph    : public AudioProcessorGraph
                         , public ChangeListener
 {
@@ -60,11 +62,14 @@ public:
     GenericProcessor* createProcessorFromDescription(Array<var>& description);
 
     void removeProcessor(GenericProcessor* processor);
-    Array<GenericProcessor*> getListOfProcessors();
+    Array<GenericProcessor*> getListOfProcessors() const;
     void clearSignalChain();
 
     bool enableProcessors();
     bool disableProcessors();
+
+    void enableHttpServer();
+    void disableHttpServer();
 
     RecordNode* getRecordNode();
     AudioNode* getAudioNode();
@@ -103,6 +108,7 @@ public:
 
 private:
     int currentNodeId;
+    std::unique_ptr<ProcessorGraphHttpServer> http_server_thread;
 
     enum nodeIds
     {

--- a/Source/Processors/ProcessorGraph/ProcessorGraphHttpServer.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraphHttpServer.h
@@ -1,0 +1,247 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2014 Open Ephys
+
+    ------------------------------------------------------------------
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef __PROCESSORGRAPHHTTPSERVER_H_124F8B50__
+#define __PROCESSORGRAPHHTTPSERVER_H_124F8B50__
+
+#include "ProcessorGraph.h"
+#include "../Parameter/Parameter.h"
+#include "../GenericProcessor/GenericProcessor.h"
+#include <sstream>
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+
+/**
+ * HTTP server thread for controlling Processor Parameters via an HTTP API. This starts an HTTP server on port 37497
+ * (== "EPHYS" on a phone keypad) and allows remote mainpulation of parameters of processors currently in the graph.
+ *
+ * The API is "RESTful", such that the resource URLs are:
+ * - GET /api/processors
+ * - GET /api/processors/<processor_id>
+ * - GET /api/processors/<processor_id>/parameters
+ * - GET /api/processors/<processor_id>/parameters/<parameter_name>
+ * - PUT /api/processors/<processor_id>/parameters/<parameter_name>
+ *
+ * All endpoints are JSON endpoints. The PUT endpoint expects two parameters: "channel" (an integer), and "value",
+ * which should have a type matching the type of the parameter.
+ */
+class ProcessorGraphHttpServer : juce::Thread {
+public:
+    static const int PORT = 37497;
+
+    explicit ProcessorGraphHttpServer(ProcessorGraph *graph) :
+            graph_(graph),
+            juce::Thread("HttpServer") {}
+
+    void run() override {
+        svr_->Get("/api/processors", [this](const httplib::Request &, httplib::Response &res) {
+            auto processors = graph_->getListOfProcessors();
+
+            std::vector<json> processors_json;
+            for (const auto &processor : processors) {
+                json processor_json;
+                processor_to_json(processor, &processor_json);
+                processors_json.push_back(processor_json);
+            }
+            json ret;
+            ret["processors"] = processors_json;
+
+            res.set_content(ret.dump(), "application/json");
+        });
+        svr_->Get(R"(/api/processors/([0-9]+))", [this](const httplib::Request &req, httplib::Response &res) {
+            auto processor = find_processor(req.matches[1]);
+            if (processor == nullptr) {
+                res.status = 404;
+                return;
+            }
+            json processor_json;
+            processor_to_json(processor, &processor_json);
+            res.set_content(processor_json.dump(), "application/json");
+        });
+        svr_->Get(R"(/api/processors/([0-9]+)/parameters)", [this](const httplib::Request &req, httplib::Response &res) {
+            auto processor = find_processor(req.matches[1]);
+            if (processor == nullptr) {
+                res.status = 404;
+                return;
+            }
+            std::vector<json> parameters_json;
+            parameters_to_json(processor, &parameters_json);
+            json ret;
+            ret["parameters"] = parameters_json;
+            res.set_content(ret.dump(), "application/json");
+        });
+        svr_->Get(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_]+))",
+                 [this](const httplib::Request &req, httplib::Response &res) {
+                     auto processor = find_processor(req.matches[1]);
+                     if (processor == nullptr) {
+                         res.status = 404;
+                         return;
+                     }
+
+                     auto parameter = find_parameter(processor, req.matches[2]);
+                     if (parameter == nullptr) {
+                         res.status = 404;
+                         return;
+                     }
+
+                     json ret;
+                     parameter_to_json(parameter, &ret);
+                     res.set_content(ret.dump(), "application/json");
+                 });
+        svr_->Put(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_]+))",
+                 [this](const httplib::Request &req, httplib::Response &res) {
+                     auto processor = find_processor(req.matches[1]);
+                     if (processor == nullptr) {
+                         res.status = 404;
+                         return;
+                     }
+
+                     auto parameter = find_parameter(processor, req.matches[2]);
+                     if (parameter == nullptr) {
+                         res.status = 404;
+                         return;
+                     }
+
+                     json request_json = json::parse(req.body);
+                     if (!request_json.contains("channel") || !request_json.contains("value")) {
+                         res.set_content("Request must contain channel and value.", "text/plain");
+                         res.status = 400;
+                         return;
+                     }
+
+                     int channel = request_json["channel"];
+                     auto value = request_json["value"];
+
+                     var val;
+                     if (value.is_number_integer()) {
+                         val = var(value.get<int>());
+                     } else if (value.is_number_float()) {
+                         val = var(value.get<float>());
+                     } else if (value.is_boolean()) {
+                         val = var(value.get<bool>());
+                     }
+
+                     bool did_set = parameter->setValue(val, channel);
+                     if (!did_set) {
+                         std::stringstream ss;
+                         ss << "Failed to set parameter value " << val.toString();
+                         res.set_content(ss.str(), "text/plain");
+                         res.status = 400;
+                         return;
+                     }
+
+                     json ret;
+                     parameter_to_json(parameter, &ret);
+                     res.set_content(ret.dump(), "application/json");
+                 });
+
+        std::cout << "Beginning HTTP server on port " << PORT << std::endl;
+        svr_->listen("0.0.0.0", PORT);
+    }
+
+    void start() {
+        if (!svr_) {
+            svr_ = std::make_unique<httplib::Server>();
+        }
+        startThread();
+    }
+
+    void stop() {
+        if (svr_) {
+            std::cout << "Shutting down HTTP server" << std::endl;
+            svr_->stop();
+        }
+        stopThread(1000);
+    }
+
+private:
+    std::unique_ptr<httplib::Server> svr_;
+    const ProcessorGraph *graph_;
+
+    inline static void parameter_to_json(Parameter *parameter, json *parameter_json) {
+        (*parameter_json)["name"] = parameter->getName().toStdString();
+        (*parameter_json)["type"] = parameter->getParameterTypeString().toStdString();
+
+        std::vector<json> values_json;
+        for (int chidx = 0; chidx < parameter->getNumChannels(); chidx++) {
+            json value_json;
+            value_json["channel"] = chidx;
+            const var &val = parameter->getValue(chidx);
+            if (parameter->isBoolean()) {
+                value_json["value"] = val.operator bool();
+            } else if (parameter->isContinuous() || parameter->isNumerical()) {
+                value_json["value"] = val.operator double();
+            } else if (parameter->isDiscrete()) {
+                value_json["value"] = val.operator int();
+            } else {
+                value_json["value"] = "UNKNOWN";
+            }
+
+            values_json.push_back(value_json);
+        }
+        (*parameter_json)["values"] = values_json;
+    }
+
+    inline static void parameters_to_json(GenericProcessor *processor, std::vector<json> *parameters_json) {
+        for (const auto &parameter : processor->parameters) {
+            json parameter_json;
+            parameter_to_json(parameter, &parameter_json);
+            parameters_json->push_back(parameter_json);
+        }
+    }
+
+    inline static void processor_to_json(GenericProcessor *processor, json *processor_json) {
+        (*processor_json)["id"] = processor->getNodeId();
+        (*processor_json)["name"] = processor->getName().toStdString();
+
+        std::vector<json> parameters_json;
+        parameters_to_json(processor, &parameters_json);
+        (*processor_json)["parameters"] = parameters_json;
+    }
+
+    inline GenericProcessor *find_processor(const std::string &id_string) {
+        int processor_id = juce::String(id_string).getIntValue();
+
+        auto processors = graph_->getListOfProcessors();
+        for (const auto &processor : processors) {
+            if (processor->getNodeId() == processor_id) {
+                return processor;
+            }
+        }
+
+        return nullptr;
+    }
+
+    static inline Parameter *find_parameter(GenericProcessor *processor, const std::string &parameter_name) {
+        Parameter *parameter = processor->getParameterByName(juce::String(parameter_name));
+        if (parameter->getName().compare(parameter_name) != 0) {
+            return nullptr;
+        }
+        return parameter;
+    }
+};
+
+#endif  // __PROCESSORGRAPH_H_124F8B50__

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -370,6 +370,7 @@ PopupMenu UIComponent::getMenuForIndex(int menuIndex, const String& menuName)
 		menu.addCommandItem(commandManager, saveConfigurationAs);
 		menu.addSeparator();
 		menu.addCommandItem(commandManager, reloadOnStartup);
+        menu.addCommandItem(commandManager, toggleHttpServer);
 
 #if !JUCE_MAC
 		menu.addSeparator();
@@ -430,6 +431,7 @@ void UIComponent::getAllCommands(Array <CommandID>& commands)
 		saveConfiguration,
 		saveConfigurationAs,
 		reloadOnStartup,
+        toggleHttpServer,
 		undo,
 		redo,
 		copySignalChain,
@@ -475,6 +477,12 @@ void UIComponent::getCommandInfo(CommandID commandID, ApplicationCommandInfo& re
 			result.setActive(!acquisitionStarted);
 			result.setTicked(mainWindow->shouldReloadOnStartup);
 			break;
+
+        case toggleHttpServer:
+            result.setInfo("Enable HTTP Server", "Enable the HTTP server on port 37497.", "General", 0);
+            result.setActive(!acquisitionStarted);
+            result.setTicked(mainWindow->shouldEnableHttpServer);
+            break;
 
 		case undo:
 			result.setInfo("Undo", "Undo the last action.", "General", 0);
@@ -637,6 +645,16 @@ bool UIComponent::perform(const InvocationInfo& info)
 				url.launchInDefaultBrowser();
 				break;
 			}
+
+        case toggleHttpServer: {
+            mainWindow->shouldEnableHttpServer = !mainWindow->shouldEnableHttpServer;
+            if (mainWindow->shouldEnableHttpServer) {
+                AccessClass::getProcessorGraph()->enableHttpServer();
+            } else {
+                AccessClass::getProcessorGraph()->disableHttpServer();
+            }
+        }
+            break;
 
 		case toggleProcessorList:
 			processorList->toggleState();

--- a/Source/UI/UIComponent.h
+++ b/Source/UI/UIComponent.h
@@ -189,7 +189,8 @@ private:
         resizeWindow            = 0x2012,
         reloadOnStartup         = 0x2013,
         saveConfigurationAs     = 0x2014,
-		openTimestampSelectionWindow = 0x2015
+		openTimestampSelectionWindow = 0x2015,
+        toggleHttpServer	    = 0x2016,
     };
 
     File currentConfigFile;


### PR DESCRIPTION
Initial implementation of a RESTful HTTP API for controlling processor
parameters. The idea is that OpenEphys GUI can be a part of a larger
ecosystem during a running experiment, and these components might need
to communicate with one another. Adding an HTTP API such as one here
allows the setting / getting of parameters to synchronize different
components (e.g. filter settings, session names, etc.).

This starts an HTTP server on port 37497 (== "EPHYS" on a phone keypad).