### PR TITLE
Supporting N-D PCA instead of hardcoding 2

### DIFF
--- a/Plugins/SpikeSorter/SpikeSorter.cpp
+++ b/Plugins/SpikeSorter/SpikeSorter.cpp
@@ -925,8 +925,10 @@ void SpikeSorter::process(AudioSampleBuffer& buffer)
             if (electrode->spikePlot != nullptr) {
                 if (electrode->spikeSort->isPCAfinished()) {
                     electrode->spikeSort->resetJobStatus();
+
                     float p1min, p2min, p1max, p2max;
-                    electrode->spikeSort->getPCArange(p1min, p2min, p1max, p2max);
+                    electrode->spikeSort->getPCArange(0, p1min, p1max);
+                    electrode->spikeSort->getPCArange(1, p2min, p2max);
                     electrode->spikePlot->setPCARange(p1min, p2min, p1max, p2max);
                 }
                 electrode->spikePlot->processSpikeObject(sorterSpike);

--- a/Plugins/SpikeSorter/SpikeSorterCanvas.h
+++ b/Plugins/SpikeSorter/SpikeSorterCanvas.h
@@ -309,7 +309,6 @@ public:
     void mouseDrag(const juce::MouseEvent& event);
     bool keyPressed(const KeyPress& key);
     void mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel);
-    void redraw(bool subsample);
 
     void updateUnits(std::vector<PCAUnit> _units);
 


### PR DESCRIPTION
Relaxes the underlying infrastructure to support more than 2 PCs, though
the (a) matching process with a polygon is still 2D, and (b) the display
is fixed to the first 2 components.

Also it seems that the loading/saving of the PCA details into the XML
was broken before this. The saving of the PCA details would save under
the <ELECTRODE> node, but the loading was looking for the PCA details in
the <SPIKESORTING> node.