### PR TITLE
Allowing pausing of PCA job

### DIFF
--- a/Plugins/SpikeSorter/SpikeSortBoxes.cpp
+++ b/Plugins/SpikeSorter/SpikeSortBoxes.cpp
@@ -922,10 +922,10 @@ void SpikeSortBoxes::projectOnPrincipalComponents(SorterSpikePtr so)
     {
         // add a spike object to the buffer.
         // if we have enough spikes, start the PCA computation thread.
-        if ((spikeBufferIndex == bufferSize -1 && !bPCAcomputed && !bPCAJobSubmitted) || bRePCA)
-        {
+        bool spikeBufferFull = spikeBufferIndex == bufferSize - 1;
+        if (bShouldPCA && ((spikeBufferFull && !bPCAcomputed && !bPCAJobSubmitted) || bRePCA)) {
             bPCAJobSubmitted = true;
-	    bPCAcomputed = false;
+            bPCAcomputed = false;
             bRePCA = false;
             // submit a new job to compute the spike buffer.
             PCAJobPtr job = new PCAjob(spikeBuffer, &pca_results_, bPCAjobFinished);
@@ -968,6 +968,16 @@ void SpikeSortBoxes::RePCA()
     bPCAcomputed = false;
     bPCAJobSubmitted = false;
     bRePCA = true;
+}
+
+void SpikeSortBoxes::DisablePeriodicPCA() {
+    bRePCA = false;
+    bShouldPCA = false;
+}
+
+void SpikeSortBoxes::EnablePeriodicPCA() {
+    bRePCA = true;
+    bShouldPCA = true;
 }
 
 void SpikeSortBoxes::addPCAunit(PCAUnit unit)

--- a/Plugins/SpikeSorter/SpikeSortBoxes.h
+++ b/Plugins/SpikeSorter/SpikeSortBoxes.h
@@ -311,6 +311,10 @@ public:
     void projectOnPrincipalComponents(SorterSpikePtr so);
 	bool sortSpike(SorterSpikePtr so, bool PCAfirst);
     void RePCA();
+
+    void DisablePeriodicPCA();
+    void EnablePeriodicPCA();
+
     void addPCAunit(PCAUnit unit);
     int addBoxUnit(int channel);
     int addBoxUnit(int channel, Box B);
@@ -357,7 +361,7 @@ private:
     SorterSpikeArray spikeBuffer;
     int bufferSize,spikeBufferIndex;
     PCAcomputingThread* computingThread;
-    bool bPCAJobSubmitted,bPCAcomputed,bRePCA;
+    bool bPCAJobSubmitted,bPCAcomputed,bRePCA, bShouldPCA;
     std::atomic<bool> bPCAjobFinished ;
 
     Parameter *parameter_;

--- a/Plugins/SpikeSorter/SpikeSorter.cpp
+++ b/Plugins/SpikeSorter/SpikeSorter.cpp
@@ -123,6 +123,24 @@ void SpikeSorter::setNumPostSamples(int numSamples)
     }
 }
 
+bool SpikeSorter::getDisablePeriodicPCA() const
+{
+    return disable_periodic_pca_;
+}
+
+void SpikeSorter::setDisablePeriodicPCA(bool disable_periodic_pca)
+{
+    disable_periodic_pca_ = disable_periodic_pca;
+    for (int k = 0; k < electrodes.size(); k++)
+    {
+        if (disable_periodic_pca) {
+            electrodes[k]->spikeSort->DisablePeriodicPCA();
+        } else {
+            electrodes[k]->spikeSort->EnablePeriodicPCA();
+        }
+    }
+}
+
 
 int SpikeSorter::getUniqueProbeID(String type)
 {
@@ -1061,7 +1079,8 @@ void SpikeSorter::saveCustomParametersToXml(XmlElement* parentElement)
     mainNode->setAttribute("autoDACassignment",	autoDACassignment);
     mainNode->setAttribute("syncThresholds",syncThresholds);
     mainNode->setAttribute("uniqueID",uniqueID);
-    mainNode->setAttribute("flipSignal",flipSignal);
+    mainNode->setAttribute("flipSignal", flipSignal);
+    mainNode->setAttribute("disablePeriodicPCA", getDisablePeriodicPCA());
 
     XmlElement* countNode = mainNode->createNewChildElement("ELECTRODE_COUNTER");
 
@@ -1207,6 +1226,9 @@ void SpikeSorter::loadCustomParametersFromXml()
 
                     }
                 }
+
+                // Ensure this is done *after* populating electrodes, so the setting propagates properly.
+                setDisablePeriodicPCA(mainNode->getBoolAttribute("disablePeriodicPCA", false));
             }
         }
     }

--- a/Plugins/SpikeSorter/SpikeSorter.h
+++ b/Plugins/SpikeSorter/SpikeSorter.h
@@ -368,6 +368,8 @@ public:
     int getNumPostSamples();
     void setNumPreSamples(int numSamples);
     void setNumPostSamples(int numSamples);
+    bool getDisablePeriodicPCA() const;
+    void setDisablePeriodicPCA(bool disable_periodic_pca);
     int getDACassignment(int channel);
     void assignDACtoChannel(int dacOutput, int channel);
     Array<int> getDACassignments();
@@ -452,10 +454,10 @@ private:
 
     OwnedArray<Electrode> electrodes;
     PCAcomputingThread computingThread;
-
+    bool disable_periodic_pca_;
     bool editAll = false;
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpikeSorter);
 
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SpikeSorter);
 };
 
 

--- a/Plugins/SpikeSorter/SpikeSorterEditor.cpp
+++ b/Plugins/SpikeSorter/SpikeSorterEditor.cpp
@@ -329,6 +329,7 @@ void SpikeSorterEditor::buttonEvent(Button* button)
         configMenu.addSubMenu("Waveform",waveSizeMenu,true);
         configMenu.addItem(5,"Current Channel => Audio",true,processor->getAutoDacAssignmentStatus());
         configMenu.addItem(6,"Threshold => All channels",true,processor->getThresholdSyncStatus());
+        configMenu.addItem(8,"Disable periodic PCA",true,processor->getDisablePeriodicPCA());
 
         const int result = configMenu.show();
         switch (result)
@@ -358,6 +359,9 @@ void SpikeSorterEditor::buttonEvent(Button* button)
                 break;
             case 7:
                 processor->setFlipSignalState(!processor->getFlipSignalState());
+                break;
+            case 8:
+                processor->setDisablePeriodicPCA(!processor->getDisablePeriodicPCA());
                 break;
         }
 


### PR DESCRIPTION
Allowing the pausing of the PCA jobs for all electrodes in the
SpikeSorter, which is useful for (a) if setting PCs via the API or (b)
if you don't want your sorting to change over time.