### PR TITLE
Allowing handling, setting, and drawing of N-D ellipses

### DIFF
--- a/Plugins/SpikeSorter/SpikeSorter.cpp
+++ b/Plugins/SpikeSorter/SpikeSorter.cpp
@@ -277,8 +277,9 @@ Electrode::Electrode(int ID,
     spikePlot = nullptr;
 
     std::stringstream parameter_name;
-    parameter_name << "electrode" << std::setfill('0') << std::setw(4) << ID;
-    parameter_ = new Parameter(
+    parameter_name << "electrode" << std::setfill('0') << std::setw(4) << ID
+                   << ".pca";
+    pca_parameter_ = new Parameter(
             juce::String(parameter_name.str()),
             juce::String("{}"),
             ID,
@@ -289,15 +290,15 @@ Electrode::Electrode(int ID,
                                        numChannels,
                                        samplingRate,
                                        pre + post,
-                                       parameter_);
+                                       pca_parameter_);
     else
         spikeSort = nullptr;
 
     isMonitored = false;
 }
 
-Parameter *Electrode::ParameterToRegister() {
-    return parameter_;
+std::vector<Parameter *> Electrode::ParametersToRegister() {
+    return std::vector<Parameter *>({pca_parameter_ });
 }
 
 void Electrode::recreate_threshold_crossing_calculator() {
@@ -551,7 +552,9 @@ bool SpikeSorter::addElectrode(int nChans, String name, double Depth)
                                             getSampleRate(),
                                             dataChannelArray[chans[0]]->getSourceNodeID(),
                                             dataChannelArray[chans[0]]->getSubProcessorIdx());
-    parameters.add(newElectrode->ParameterToRegister());
+    for (auto parameter : newElectrode->ParametersToRegister()) {
+        parameters.add(parameter);
+    }
 
     newElectrode->depthOffsetMM = Depth;
     String log = "Added electrode (ID "+ String(uniqueID)+") with " + String(nChans) + " channels." ;
@@ -1213,7 +1216,10 @@ void SpikeSorter::loadCustomParametersFromXml()
                             newElectrode->set_threshold(k, thres[k]);
                             newElectrode->set_is_active(k, isActive[k]);
                         }
-                        parameters.add(newElectrode->ParameterToRegister());
+
+                        for (auto parameter : newElectrode->ParametersToRegister()) {
+                            parameters.add(parameter);
+                        }
                         delete[] channels;
                         delete[] thres;
                         delete[] isActive;

--- a/Plugins/SpikeSorter/SpikeSorter.h
+++ b/Plugins/SpikeSorter/SpikeSorter.h
@@ -165,7 +165,7 @@ public:
     ~Electrode();
 
     void resizeWaveform(int numPre, int numPost);
-    Parameter *ParameterToRegister();
+    std::vector<Parameter *> ParametersToRegister();
 
     String name;
 
@@ -207,7 +207,7 @@ private:
     bool* isActive_;
     int* channels_;
     void recreate_threshold_crossing_calculator();
-    Parameter *parameter_;
+    Parameter *pca_parameter_;
 };
 
 class ContinuousCircularBuffer

--- a/Plugins/SpikeSorter/SpikeSorterCanvas.h
+++ b/Plugins/SpikeSorter/SpikeSorterCanvas.h
@@ -310,11 +310,8 @@ public:
     bool keyPressed(const KeyPress& key);
     void mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel);
 
-    void updateUnits(std::vector<PCAUnit> _units);
-
     void buttonClicked(Button* button);
 
-    void drawUnit(Graphics& g, PCAUnit unit);
     void rangeDown();
     void rangeUp();
 
@@ -322,6 +319,7 @@ private:
     float prevx,prevy;
     bool inPolygonDrawingMode;
 	void drawProjectedSpike(SorterSpikePtr s);
+    void drawUnit(Graphics& g, PCAUnit unit);
 
     bool rangeSet;
     SpikeSorter* processor;
@@ -332,7 +330,6 @@ private:
     SorterSpikeArray spikeBuffer;
     int bufferSize;
     int spikeIndex;
-    bool updateProcessor;
 	void calcWaveformPeakIdx(SorterSpikePtr, int, int, int*, int*);
 
     Image projectionImage;
@@ -349,8 +346,6 @@ private:
 
     float pcaMin[2],pcaMax[2];
     std::list<PointD> drawnPolygon;
-
-    std::vector<PCAUnit> units;
     int isOverUnit;
     PCAUnit drawnUnit;
 
@@ -413,7 +408,6 @@ private:
     double limits[MAX_N_CHAN][2];
 
     std::vector<BoxUnit> boxUnits;
-    std::vector<PCAUnit> pcaUnits;
     SpikeSorter* processor;
     OwnedArray<PCAProjectionAxes> pAxes;
     OwnedArray<WaveformAxes> wAxes;

--- a/Source/Processors/ProcessorGraph/ProcessorGraphHttpServer.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraphHttpServer.h
@@ -93,7 +93,7 @@ public:
             ret["parameters"] = parameters_json;
             res.set_content(ret.dump(), "application/json");
         });
-        svr_->Get(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_]+))",
+        svr_->Get(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_\.\-]+))",
                  [this](const httplib::Request &req, httplib::Response &res) {
                      auto processor = find_processor(req.matches[1]);
                      if (processor == nullptr) {
@@ -111,7 +111,7 @@ public:
                      parameter_to_json(parameter, &ret);
                      res.set_content(ret.dump(), "application/json");
                  });
-        svr_->Put(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_]+))",
+        svr_->Put(R"(/api/processors/([0-9]+)/parameters/([A-Za-z0-9_\.\-]+))",
                  [this](const httplib::Request &req, httplib::Response &res) {
                      auto processor = find_processor(req.matches[1]);
                      if (processor == nullptr) {


### PR DESCRIPTION
Allowing the use of N-D ellipses, in addition to 2-D hand-drawn
polygons, for spike sorting. These changes include adapting PointD to be
fully N-dimensional (instead of a hard-coded 2-dimensions), grouping the
PCA details together and allowing serialization/deserialization via
JSON/the HTTP API, and the display of the ellipse in 2 dimensions.