### PR TITLE
Allowing configurable order and bigger freq range in filters

### DIFF
--- a/Plugins/FilterNode/FilterEditor.h
+++ b/Plugins/FilterNode/FilterEditor.h
@@ -50,7 +50,7 @@ public:
     void saveCustomParameters(XmlElement* xml);
     void loadCustomParameters(XmlElement* xml);
 
-    void setDefaults(double lowCut, double highCut);
+    void setDefaults(double lowCut, double highCut, int order);
     void resetToSavedText();
 
     void channelChanged (int chan, bool newState);
@@ -59,12 +59,15 @@ private:
 
     String lastHighCutString;
     String lastLowCutString;
+    String lastOrderString;
 
     ScopedPointer<Label> highCutLabel;
     ScopedPointer<Label> lowCutLabel;
+    ScopedPointer<Label> orderLabel;
 
     ScopedPointer<Label> highCutValue;
     ScopedPointer<Label> lowCutValue;
+    ScopedPointer<Label> orderValue;
     ScopedPointer<UtilityButton> applyFilterOnADC;
     ScopedPointer<UtilityButton> applyFilterOnChan;
 

--- a/Plugins/FilterNode/FilterNode.h
+++ b/Plugins/FilterNode/FilterNode.h
@@ -37,6 +37,12 @@
 class FilterNode : public GenericProcessor
 {
 public:
+    static const int PARAMETER_INDEX_HIGH_CUT = 1;
+    static const int PARAMETER_INDEX_LOW_CUT = 2;
+    static const int PARAMETER_INDEX_ORDER = 3;
+    static const int MAX_ORDER = 10; // max filter order allowed
+    constexpr static double MAX_FREQUENCY = 20000.0; // maximum frequency allowed for either lowcut/highcut
+
     FilterNode();
     ~FilterNode();
 
@@ -62,10 +68,11 @@ public:
 
 
 private:
-    void setFilterParameters (double, double, int);
+    void setFilterParameters (double, double, int, int);
 
     Array<double> lowCuts;
     Array<double> highCuts;
+    Array<int> orders;
 
     OwnedArray<Dsp::Filter> filters;
     Array<bool> shouldFilterChannel;
@@ -74,6 +81,7 @@ private:
 
     double defaultLowCut;
     double defaultHighCut;
+    int defaultOrder;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (FilterNode);
 };


### PR DESCRIPTION
Allowing a configurable order in the filters and a larger freq range in
filters. The latter is for a "hack" to do only a highpass filter by
setting the highcut value to something > fs/2 to have minimal effect.