### PR TITLE
Allowing control of thresholds from the API

### DIFF
--- a/Plugins/SpikeSorter/CMakeLists.txt.in.tcrosser
+++ b/Plugins/SpikeSorter/CMakeLists.txt.in.tcrosser
@@ -5,7 +5,7 @@ project(tcrosser-download NONE)
 include(ExternalProject)
 ExternalProject_Add(tcrosser
   GIT_REPOSITORY    git@github.com:carmenalab/c.git
-  GIT_TAG           botros/cmake
+  GIT_TAG           master
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/tcrosser-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/tcrosser-build"
   CONFIGURE_COMMAND ""

--- a/Plugins/SpikeSorter/SpikeSortBoxes.cpp
+++ b/Plugins/SpikeSorter/SpikeSortBoxes.cpp
@@ -632,7 +632,7 @@ void SpikeSortBoxes::synchronizePCAParameter() {
     pca_parameter_->setValue(pca_sorting_.ToValue(), 0);
 }
 
-void SpikeSortBoxes::parameterValueChanged(Value &valueThatWasChanged) {
+void SpikeSortBoxes::parameterValueChanged(Value &valueThatWasChanged, const String &parameterName) {
     if (pca_parameter_->getNumChannels() != 1) {
         // Something invalid? Only one channel supported.
         return;

--- a/Plugins/SpikeSorter/SpikeSortBoxes.h
+++ b/Plugins/SpikeSorter/SpikeSortBoxes.h
@@ -402,7 +402,7 @@ public:
     void resizeWaveform(int numSamples);
 
     // Parameter::Listener
-    void parameterValueChanged (Value& valueThatWasChanged) override;
+    void parameterValueChanged(Value &valueThatWasChanged, const String &parameterName) override;
 
     void projectOnPrincipalComponents(SorterSpikePtr so);
 	bool sortSpike(SorterSpikePtr so, bool PCAfirst);

--- a/Plugins/SpikeSorter/SpikeSorterCanvas.cpp
+++ b/Plugins/SpikeSorter/SpikeSorterCanvas.cpp
@@ -629,6 +629,14 @@ void SpikeHistogramPlot::setFlipSignal(bool state)
     }
 }
 
+void SpikeHistogramPlot::refreshThresholdSliders() {
+    for (int i = 0; i < wAxes.size(); i++)
+    {
+        wAxes[i]->setDetectorThreshold(processor->getActiveElectrode()->get_threshold(i));
+        wAxes[i]->repaint();
+    }
+}
+
 void SpikeHistogramPlot::setPolygonDrawingMode(bool on)
 {
     const ScopedLock myScopedLock(mut);
@@ -1197,25 +1205,6 @@ bool WaveformAxes::updateSpikeData(SorterSpikePtr s)
     }
 
     return true;
-
-}
-
-bool WaveformAxes::checkThreshold(SorterSpikePtr s)
-{
-    int sampIdx = s->getChannel()->getTotalSamples()*type;
-
-	for (int i = 0; i < s->getChannel()->getTotalSamples() - 1; i++)
-    {
-
-        if (s->getData()[sampIdx] > displayThresholdLevel)
-        {
-            return true;
-        }
-
-        sampIdx++;
-    }
-
-    return false;
 
 }
 

--- a/Plugins/SpikeSorter/SpikeSorterCanvas.h
+++ b/Plugins/SpikeSorter/SpikeSorterCanvas.h
@@ -213,7 +213,6 @@ public:
 
 
 	bool updateSpikeData(SorterSpikePtr s);
-	bool checkThreshold(SorterSpikePtr spike);
 
     void setSignalFlip(bool state);
     void paint(Graphics& g);
@@ -259,7 +258,6 @@ private:
     bool drawGrid;
 
     float displayThresholdLevel;
-    float detectorThresholdLevel;
 
     void drawWaveformGrid(Graphics& g);
 
@@ -361,6 +359,14 @@ public:
 
     void paint(Graphics& g);
     void resized();
+
+    /**
+     * Refresh the threshold slides for all of the waveform axes, in case the threshold is changed out-of-band (e.g.,
+     * set via the API, updated by a separate process, etc.). Ensure the message manager lock is held if calling from
+     * a different thread; you should get a debug assertion if compiling in Debug if the lock is needed.
+     * */
+    void refreshThresholdSliders();
+
     void setFlipSignal(bool state);
 
     void select();

--- a/Source/Processors/Parameter/Parameter.cpp
+++ b/Source/Processors/Parameter/Parameter.cpp
@@ -444,7 +444,7 @@ void Parameter::valueChanged (Value& valueThatWasChanged)
         m_possibleValues = possibleValues;
     }
 
-    m_listeners.call (&Parameter::Listener::parameterValueChanged, valueThatWasChanged);
+    m_listeners.call (&Parameter::Listener::parameterValueChanged, valueThatWasChanged, getName());
 }
 
 

--- a/Source/Processors/Parameter/Parameter.h
+++ b/Source/Processors/Parameter/Parameter.h
@@ -47,7 +47,7 @@ public:
     public:
         virtual ~Listener() {}
 
-        virtual void parameterValueChanged (Value& valueThatWasChanged) = 0;
+        virtual void parameterValueChanged(Value &valueThatWasChanged, const String &parameterName) = 0;
     };
 
     enum ParameterType


### PR DESCRIPTION
- Allowing the control of thresholds via the API in the SpikeSorter.
- Adding a "parameter name" parameter to any listeners of a parameter;
in this case this is useful to disambiguate many listened parameters in
the same listener.
- Getting rid of separate thresholds array in the SpikeSorter; now
single source of truth lies in the tcrosser layer.
- Some changes to allow for updating the threshold slider display when
they're changed out-of-band. Useful for when changed by the API or if
there are fancier threshold-setting-mechanisms in the future (e.g.
adaptive).