### PR TITLE
Fixing couple bugs in FilterNode

### DIFF
--- a/Plugins/FilterNode/FilterEditor.cpp
+++ b/Plugins/FilterNode/FilterEditor.cpp
@@ -181,8 +181,9 @@ void FilterEditor::labelTextChanged(Label* label)
             }
 
             lastLowCutString = label->getText();
-        } else {
+        } else if (label == orderValue) {
             if (requestedValue > 0 && roundDoubleToInt(requestedValue) <= FilterNode::MAX_ORDER) {
+                fn->setCurrentChannel(chans[n]);
                 fn->setParameter(FilterNode::PARAMETER_INDEX_ORDER, requestedValue);
                 lastOrderString = label->getText();
             } else {
@@ -200,8 +201,8 @@ void FilterEditor::channelChanged (int channel, bool /*newState*/)
 
     highCutValue->setText (String (fn->getHighCutValueForChannel (channel)), dontSendNotification);
     lowCutValue->setText  (String (fn->getLowCutValueForChannel  (channel)), dontSendNotification);
+    orderValue->setText  (String (fn->getOrderValueForChannel(channel)), dontSendNotification);
     applyFilterOnChan->setToggleState (fn->getBypassStatusForChannel (channel), dontSendNotification);
-
 }
 
 void FilterEditor::buttonEvent(Button* button)
@@ -224,7 +225,7 @@ void FilterEditor::buttonEvent(Button* button)
             float newValue = button->getToggleState() ? 1.0 : 0.0;
 
             fn->setCurrentChannel(chans[n]);
-            fn->setParameter(2, newValue);
+            fn->setParameter(FilterNode::PARAMETER_INDEX_ENABLE, newValue);
         }
     }
 }
@@ -237,10 +238,12 @@ void FilterEditor::saveCustomParameters(XmlElement* xml)
 
     lastHighCutString = highCutValue->getText();
     lastLowCutString = lowCutValue->getText();
+    lastOrderString = orderValue->getText();
 
     XmlElement* textLabelValues = xml->createNewChildElement("VALUES");
     textLabelValues->setAttribute("HighCut",lastHighCutString);
-    textLabelValues->setAttribute("LowCut",lastLowCutString);
+    textLabelValues->setAttribute("LowCut", lastLowCutString);
+    textLabelValues->setAttribute("Order", lastOrderString);
     textLabelValues->setAttribute("ApplyToADC",	applyFilterOnADC->getToggleState());
 }
 
@@ -253,6 +256,7 @@ void FilterEditor::loadCustomParameters(XmlElement* xml)
         {
             lastHighCutString = xmlNode->getStringAttribute("HighCut", lastHighCutString);
             lastLowCutString = xmlNode->getStringAttribute("LowCut", lastLowCutString);
+            lastOrderString = xmlNode->getStringAttribute("Order", lastOrderString);
             resetToSavedText();
 
             applyFilterOnADC->setToggleState(xmlNode->getBoolAttribute("ApplyToADC",false), sendNotification);

--- a/Plugins/FilterNode/FilterNode.cpp
+++ b/Plugins/FilterNode/FilterNode.cpp
@@ -205,6 +205,11 @@ double FilterNode::getHighCutValueForChannel (int chan) const
     return highCuts[chan];
 }
 
+int FilterNode::getOrderValueForChannel (int chan) const
+{
+    return orders[chan];
+}
+
 
 bool FilterNode::getBypassStatusForChannel (int chan) const
 {
@@ -253,8 +258,7 @@ void FilterNode::setParameter (int parameterIndex, float newValue)
         editor->updateParameterButtons (parameterIndex);
     }
     // change channel bypass state
-    else
-    {
+    else if (parameterIndex == FilterNode::PARAMETER_INDEX_ENABLE) {
         if (newValue == 0)
         {
             shouldFilterChannel.set (currentChannel, false);

--- a/Plugins/FilterNode/FilterNode.h
+++ b/Plugins/FilterNode/FilterNode.h
@@ -40,6 +40,7 @@ public:
     static const int PARAMETER_INDEX_HIGH_CUT = 1;
     static const int PARAMETER_INDEX_LOW_CUT = 2;
     static const int PARAMETER_INDEX_ORDER = 3;
+    static const int PARAMETER_INDEX_ENABLE = 4;
     static const int MAX_ORDER = 10; // max filter order allowed
     constexpr static double MAX_FREQUENCY = 20000.0; // maximum frequency allowed for either lowcut/highcut
 
@@ -59,8 +60,9 @@ public:
     void saveCustomChannelParametersToXml(XmlElement* channelInfo, int channelNumber, InfoObjectCommon::InfoObjectType channelTypel) override;
     void loadCustomChannelParametersFromXml(XmlElement* channelInfo, InfoObjectCommon::InfoObjectType channelType)  override;
 
-    double getLowCutValueForChannel  (int chan) const;
-    double getHighCutValueForChannel (int chan) const;
+    double getLowCutValueForChannel(int chan) const;
+    double getHighCutValueForChannel(int chan) const;
+    int getOrderValueForChannel(int chan) const;
 
     bool getBypassStatusForChannel (int chan) const;
 


### PR DESCRIPTION
Wasn't setting the proper parameter index for toggling the filtering of
channels, and wasn't setting the "active channel" properly.