### PR TITLE
Option on Spike Viewer gizmo to always record spikes

### DIFF
--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.cpp
@@ -41,13 +41,20 @@ SpikeDisplayEditor::SpikeDisplayEditor(GenericProcessor* parentNode)
 
     tabText = "Spikes";
 
-
+    alwaysRecordButton = new UtilityButton("Always Record", Font("Default", 10, Font::plain));
+    alwaysRecordButton->addListener(this);
+    alwaysRecordButton->setBounds(10, 25, 100, 25);
+    alwaysRecordButton->setClickingTogglesState(true);
+    alwaysRecordButton->setToggleState(true, dontSendNotification);
+    alwaysRecordButton->setTooltip(
+            "When this button is on, spikes will always be recorded, even if threshold is not crossed.");
+    addAndMakeVisible(alwaysRecordButton);
 
 }
 
 SpikeDisplayEditor::~SpikeDisplayEditor()
 {
-    deleteAllChildren();
+//    deleteAllChildren();
 }
 
 void SpikeDisplayEditor::initializeButtons()
@@ -213,6 +220,11 @@ void SpikeDisplayEditor::stopRecording()
 
 void SpikeDisplayEditor::buttonEvent(Button* button)
 {
+    if (button == alwaysRecordButton.get()) {
+        auto node = (SpikeDisplayNode *) getProcessor();
+        node->setParameter(4, alwaysRecordButton->getToggleState() ? 1.0 : 0.0);
+    }
+
     //std::cout<<"Got event from component:"<<button<<std::endl;
 
     // int pIdx = 0;

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.h
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.h
@@ -59,7 +59,7 @@ public:
     Visualizer* createNewCanvas();
 
 private:
-
+    ScopedPointer<UtilityButton> alwaysRecordButton;
     UtilityButton* panUpBtn;
     UtilityButton* panDownBtn;
     UtilityButton* zoomInBtn;

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.cpp
@@ -180,6 +180,8 @@ void SpikeDisplayNode::setParameter (int param, float val)
     else if (param == 2)   // redraw
     {
         redrawRequested = true;
+    } else if (param == SpikeDisplayNode::PARAMETER_INDEX_ALWAYS_RECORD) {
+        always_record_ = val > 0;
     }
 }
 
@@ -238,13 +240,13 @@ void SpikeDisplayNode::handleSpike(const SpikeChannel* spikeInfo, const MidiMess
 		aboveThreshold = aboveThreshold | checkThreshold(i, e->displayThresholds[i], newSpike);
 	}
 
+	if (isRecording && (aboveThreshold || always_record_)) {
+        // save spike
+        CoreServices::RecordNode::writeSpike(newSpike, spikeInfo);
+	}
+
 	if (aboveThreshold)
 	{
-		// save spike
-		if (isRecording)
-		{
-			CoreServices::RecordNode::writeSpike(newSpike, spikeInfo);
-		}
 		// add to buffer
 		if (e->currentSpikeIndex < displayBufferSize)
 		{
@@ -252,8 +254,6 @@ void SpikeDisplayNode::handleSpike(const SpikeChannel* spikeInfo, const MidiMess
 			e->mostRecentSpikes.set(e->currentSpikeIndex, newSpike.release());
 			e->currentSpikeIndex++;
 		}
-
-		
 	}
 }
 

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.h
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.h
@@ -40,6 +40,8 @@ class SpikePlot;
 class SpikeDisplayNode :  public GenericProcessor
 {
 public:
+    static const int PARAMETER_INDEX_ALWAYS_RECORD = 3;
+
     SpikeDisplayNode();
     ~SpikeDisplayNode();
 
@@ -95,6 +97,7 @@ private:
 
     // members for recording
     bool isRecording;
+    bool always_record_;
     //   bool signalFilesShouldClose;
     //   RecordNode* recordNode;
     //   String baseDirectory;


### PR DESCRIPTION
No reason to have a separate threshold in the Spike Viewer as a blocker
to store spikes.