### PR TITLE
Implementing arbitrary event forwarding for River

### DIFF
--- a/Plugins/RiverOutput/CMakeLists.txt
+++ b/Plugins/RiverOutput/CMakeLists.txt
@@ -11,7 +11,8 @@ add_sources(${PLUGIN_NAME}
   RiverOutput.h
   RiverOutputEditor.cpp
   RiverOutputEditor.h
-  )
+  SchemaListBox.h
+)
 
 # ===== External Dependency: river
 configure_file(CMakeLists.txt.in.river river-download/CMakeLists.txt)

--- a/Plugins/RiverOutput/RiverOutput.h
+++ b/Plugins/RiverOutput/RiverOutput.h
@@ -43,6 +43,7 @@ public:
     void process(AudioSampleBuffer &buffer) override;
 
     void handleSpike(const SpikeChannel *spikeInfo, const MidiMessage &event, int samplePosition) override;
+    void handleEvent(const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
 
     /** Called immediately prior to the start of data acquisition. */
     bool enable() override;
@@ -71,17 +72,28 @@ public:
     const std::string &redisConnectionPassword() const;
     void setRedisConnectionPassword(const std::string &redisConnectionPassword);
 
-    std::string streamName();
+    void setEventSchema(const river::StreamSchema& eventSchema);
+    void clearEventSchema();
+    bool shouldConsumeSpikes() const;
+
+    river::StreamSchema getSchema() const;
+
+    std::string streamName() const;
+    int64_t totalSamplesWritten() const;
+
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (RiverOutput)
 
+    // For writing spikes to River. Ensure it's packed so that padding doesn't mess up the size of the struct.
     typedef struct RiverSpike {
         int32_t channel_index;
         int32_t unit_index;
         int64_t data_index;
     } __attribute__((__packed__)) RiverSpike;
+    const river::StreamSchema spike_schema_;
 
-    const river::StreamSchema &schema();
+    // If this is set, then we should listen to events, not spikes.
+    std::shared_ptr<river::StreamSchema> event_schema_;
 
     std::unique_ptr<river::StreamWriter> writer_;
 
@@ -91,6 +103,7 @@ private:
     std::string redis_connection_hostname_;
     int redis_connection_port_;
     std::string redis_connection_password_;
+
 };
 
 

--- a/Plugins/RiverOutput/RiverOutputEditor.cpp
+++ b/Plugins/RiverOutput/RiverOutputEditor.cpp
@@ -22,15 +22,15 @@
 */
 
 #include "RiverOutputEditor.h"
+#include "SchemaListBox.h"
 
 RiverOutputEditor::RiverOutputEditor(
         GenericProcessor *parentNode, bool useDefaultParameterEditors)
-        : GenericEditor(parentNode, useDefaultParameterEditors) {
+        : VisualizerEditor(parentNode, 350, useDefaultParameterEditors) {
+    tabText = "River Output";
 
-    desiredWidth = 350;
-
-    hostnameLabel = newStaticLabel("Hostname", 10,25,80,20);
-    hostnameLabelValue = newInputLabel("hostnameLabelValue", "Set the hostname for River", 15,42,80,18);
+    hostnameLabel = newStaticLabel("Hostname", 10, 25, 80, 20);
+    hostnameLabelValue = newInputLabel("hostnameLabelValue", "Set the hostname for River", 15, 42, 80, 18);
 
     portLabel = newStaticLabel("Port", 10, 65, 80, 20);
     portLabelValue = newInputLabel("hostnamePortValue", "Set the port for River", 15, 82, 60, 18);
@@ -38,11 +38,220 @@ RiverOutputEditor::RiverOutputEditor(
     passwordLabel = newStaticLabel("Password", 105, 25, 100, 20);
     passwordLabelValue = newInputLabel("hostnamePasswordValue", "Set the password for River", 110, 42, 100, 18);
 
-    streamNameLabel = newStaticLabel("Stream Name", 105, 65, 80, 20);
-    streamNameLabelValue = newInputLabel("streamNameLabelValue", "Set the port for River", 110, 82, 120, 18);
-    streamNameLabelValue->setEditable(false, false);
-    refreshLabels();
+    optionsPanel = new Component("River Options Panel");
+    // initial bounds, to be expanded
+    const int C_TEXT_HT = 25;
+    const int LEFT_EDGE = 30;
+    const int TOP_EDGE = 15;
+    const int TAB_WIDTH = 25;
+    const int LABEL_VALUE_GAP = 20;
+    int xPos, yPos;
+
+    xPos = LEFT_EDGE;
+    yPos = TOP_EDGE;
+
+    optionsPanelTitle = new Label("RiverOptionsTitle", "River Options");
+    optionsPanelTitle->setBounds(xPos, yPos, 400, 50);
+    optionsPanelTitle->setFont(Font(20, Font::bold));
+    optionsPanel->addAndMakeVisible(optionsPanelTitle);
+
+    Font subtitleFont(16, Font::bold);
+
+    /* ~~~~~~~~ Input type ~~~~~~~~ */
+
+    xPos = LEFT_EDGE;
+    yPos += 45;
+
+    inputTypeTitle = new Label("InputType", "Input Type");
+    inputTypeTitle->setBounds(xPos, yPos, 200, 50);
+    inputTypeTitle->setFont(subtitleFont);
+    optionsPanel->addAndMakeVisible(inputTypeTitle);
+
+    /* -------- Radio group #1: Spikes --------- */
+
+    xPos += TAB_WIDTH;
+    yPos += 45;
+
+    inputTypeSpikeButton = new ToggleButton("Spikes");
+    inputTypeSpikeButton->setRadioGroupId(inputTypeRadioId, dontSendNotification);
+    inputTypeSpikeButton->setBounds(xPos, yPos, 150, C_TEXT_HT);
+    inputTypeSpikeButton->setToggleState(true, dontSendNotification);
+    inputTypeSpikeButton->setTooltip("Emit spike events to River with a preset schema");
+    inputTypeSpikeButton->addListener(this);
+    optionsPanel->addAndMakeVisible(inputTypeSpikeButton);
+
+    /* -------- Radio group #1: Events (with a custom Schema) --------- */
+
+    yPos += 40;
+
+    inputTypeEventButton = new ToggleButton("Events");
+    inputTypeEventButton->setRadioGroupId(inputTypeRadioId, dontSendNotification);
+    inputTypeEventButton->setBounds(xPos, yPos, 340, C_TEXT_HT);
+    inputTypeEventButton->setToggleState(false, dontSendNotification);
+    inputTypeEventButton->setTooltip("Emit custom events to River with a given schema");
+    inputTypeEventButton->addListener(this);
+    optionsPanel->addAndMakeVisible(inputTypeEventButton);
+    yPos += 60;
+
+    xPos = LEFT_EDGE;
+    fieldNameLabel = newStaticLabel("Field Name:", xPos, yPos, 140, C_TEXT_HT, optionsPanel);
+    fieldNameLabelValue = newInputLabel("fieldNameLabelValue",
+                                        "Name of the new field",
+                                        xPos,
+                                        yPos + LABEL_VALUE_GAP,
+                                        100,
+                                        C_TEXT_HT,
+                                        optionsPanel);
+
+    xPos += fieldNameLabel->getBounds().getWidth() + 4;
+    fieldTypeLabel = newStaticLabel("Field Type:", xPos, yPos, 80, C_TEXT_HT, optionsPanel);
+    optionsPanel->addAndMakeVisible(fieldTypeLabel);
+    fieldTypeComboBox = new ComboBox("Field Type:");
+    fieldTypeComboBox->setBounds(xPos, yPos + LABEL_VALUE_GAP, 100, C_TEXT_HT);
+    fieldTypeComboBox->addItem("DOUBLE", 1);
+    fieldTypeComboBox->addItem("FLOAT", 2);
+    fieldTypeComboBox->addItem("INT32", 3);
+    fieldTypeComboBox->addItem("INT64", 4);
+    fieldTypeComboBox->addListener(this);
+    optionsPanel->addAndMakeVisible(fieldTypeComboBox);
+
+    xPos += fieldTypeComboBox->getBounds().getWidth() + 20;
+
+    addFieldButton = new UtilityButton("+", titleFont);
+    addFieldButton->setBounds(xPos, yPos + LABEL_VALUE_GAP, 20, C_TEXT_HT);
+    addFieldButton->setRadius(3.0f);
+    addFieldButton->addListener(this);
+    optionsPanel->addAndMakeVisible(addFieldButton);
+
+    xPos += addFieldButton->getBounds().getWidth() + 4;
+    removeSelectedFieldButton = new UtilityButton("-", titleFont);
+    removeSelectedFieldButton->setBounds(xPos, yPos + LABEL_VALUE_GAP, 20, C_TEXT_HT);
+    removeSelectedFieldButton->setRadius(3.0f);
+    removeSelectedFieldButton->addListener(this);
+    optionsPanel->addAndMakeVisible(removeSelectedFieldButton);
+
+    xPos = LEFT_EDGE;
+    yPos += 60;
+
+    schemaList = new SchemaListBox();
+    schemaList->setBounds(xPos, yPos, 300, 400);
+    optionsPanel->addAndMakeVisible(schemaList);
+
+    // Move to right half, even with the title
+    xPos = LEFT_EDGE + 400;
+    yPos = inputTypeTitle->getY();
+    streamNameLabel = newStaticLabel("Stream Name", xPos, yPos, 80, 20, optionsPanel);
+    streamNameLabelValue = newStaticLabel("N/A",
+                                          xPos,
+                                          yPos + LABEL_VALUE_GAP,
+                                          200,
+                                          18,
+                                          optionsPanel);
+
+    // Move to right half, even with the title
+    yPos += 60;
+    totalSamplesWrittenLabel = newStaticLabel("Samples Written", xPos, yPos, 150, 20, optionsPanel);
+    totalSamplesWrittenLabelValue = newStaticLabel("0",
+                                                   xPos,
+                                                   yPos + LABEL_VALUE_GAP,
+                                                   120,
+                                                   18,
+                                                   optionsPanel);
+
+    // Update the bounds of the options panel to fit all of the components in it:
+    juce::Rectangle<int> opBounds(0, 0, 1, 1);
+    for (const Component *component : {
+            dynamic_cast<Component *>(optionsPanel.get()),
+            dynamic_cast<Component *>(optionsPanelTitle.get()),
+            dynamic_cast<Component *>(inputTypeTitle.get()),
+            dynamic_cast<Component *>(inputTypeSpikeButton.get()),
+            dynamic_cast<Component *>(inputTypeEventButton.get()),
+            dynamic_cast<Component *>(fieldNameLabel.get()),
+            dynamic_cast<Component *>(fieldNameLabelValue.get()),
+            dynamic_cast<Component *>(fieldTypeLabel.get()),
+            dynamic_cast<Component *>(fieldTypeComboBox.get()),
+            dynamic_cast<Component *>(addFieldButton.get()),
+            dynamic_cast<Component *>(removeSelectedFieldButton.get()),
+            dynamic_cast<Component *>(schemaList.get()),
+            dynamic_cast<Component *>(streamNameLabel.get()),
+            dynamic_cast<Component *>(streamNameLabelValue.get()),
+            dynamic_cast<Component *>(totalSamplesWrittenLabel.get()),
+            dynamic_cast<Component *>(totalSamplesWrittenLabelValue.get()),
+    }) {
+        opBounds = opBounds.getUnion(component->getBounds());
+    }
+    // Plus a little buffer:
+    opBounds.setBottom(opBounds.getBottom() + 10);
+    opBounds.setRight(opBounds.getRight() + 10);
+    optionsPanel->setBounds(opBounds);
+
+    refreshLabelsFromProcessor();
 }
+
+Visualizer* RiverOutputEditor::createNewCanvas() {
+    canvas = new RiverOutputCanvas(getProcessor());
+    return canvas;
+}
+
+void RiverOutputEditor::comboBoxChanged(ComboBox *) {}
+
+void RiverOutputEditor::buttonEvent(Button *button) {
+    if (isPlaying) {
+        CoreServices::sendStatusMessage("Cannot update schema while running.");
+        return;
+    }
+
+    if (button == addFieldButton) {
+        const String &fieldName = fieldNameLabelValue->getText();
+        if (fieldName.isEmpty() || fieldTypeComboBox->getSelectedId() <= 0) {
+            return;
+        }
+
+        river::FieldDefinition::Type type;
+        int size;
+        switch (fieldTypeComboBox->getSelectedId()) {
+            case 1:
+                type = river::FieldDefinition::DOUBLE;
+                size = 8;
+                break;
+            case 2:
+                type = river::FieldDefinition::FLOAT;
+                size = 4;
+                break;
+            case 3:
+                type = river::FieldDefinition::INT32;
+                size = 4;
+                break;
+            case 4:
+                type = river::FieldDefinition::INT64;
+                size = 8;
+                break;
+            default:
+                return;
+        }
+        schemaList->addItem(river::FieldDefinition(fieldName.toStdString(), type, size));
+    } else if (button == removeSelectedFieldButton) {
+        schemaList->removeSelectedRow();
+    }
+    updateProcessorSchema();
+}
+
+void RiverOutputEditor::updateProcessorSchema() {
+    auto processor = dynamic_cast<RiverOutput *>(getProcessor());
+
+    if (inputTypeSpikeButton->getToggleState()) {
+        // Clearing event schema forces use of the spike schema / spike input type.
+        processor->clearEventSchema();
+    } else if (inputTypeEventButton->getToggleState()) {
+        auto field_definitions = schemaList->fieldDefinitions();
+        if (!field_definitions.empty()) {
+            processor->setEventSchema(river::StreamSchema(field_definitions));
+        }
+    } else {
+        // Can happen transiently where both are off briefly
+    }
+}
+
 
 void RiverOutputEditor::labelTextChanged(Label *label) {
     auto river = (RiverOutput *) getProcessor();
@@ -58,10 +267,12 @@ void RiverOutputEditor::labelTextChanged(Label *label) {
         }
     } else if (label == passwordLabelValue) {
         river->setRedisConnectionPassword(label->getText().toStdString());
+    } else if (label == fieldNameLabelValue) {
+        // Nothing to do.
     }
 }
 
-void RiverOutputEditor::refreshLabels() {
+void RiverOutputEditor::refreshLabelsFromProcessor() {
     auto river = (RiverOutput *) getProcessor();
     lastPortValue = std::to_string(river->redisConnectionPort());
 
@@ -69,15 +280,37 @@ void RiverOutputEditor::refreshLabels() {
     portLabelValue->setText(lastPortValue, dontSendNotification);
     passwordLabelValue->setText(river->redisConnectionPassword(), dontSendNotification);
     streamNameLabelValue->setText(river->streamName(), dontSendNotification);
+
+    totalSamplesWrittenLabelValue->setText(juce::String(river->totalSamplesWritten()), dontSendNotification);
+}
+
+void RiverOutputEditor::refreshSchemaFromProcessor() {
+    auto processor = dynamic_cast<RiverOutput *>(getProcessor());
+    if (processor->shouldConsumeSpikes()) {
+        inputTypeEventButton->setToggleState(false, dontSendNotification);
+        inputTypeSpikeButton->setToggleState(true, dontSendNotification);
+    } else {
+        inputTypeSpikeButton->setToggleState(false, dontSendNotification);
+        inputTypeEventButton->setToggleState(true, dontSendNotification);
+        schemaList->clearItems();
+        for (const auto& field : processor->getSchema().field_definitions) {
+            schemaList->addItem(field);
+        }
+    }
 }
 
 Label *RiverOutputEditor::newStaticLabel(
-        const std::string& labelText, int boundsX, int boundsY, int boundsWidth, int boundsHeight) {
+        const std::string &labelText,
+        int boundsX,
+        int boundsY,
+        int boundsWidth,
+        int boundsHeight,
+        Component *parent) {
     auto *label = new Label(labelText, labelText);
     label->setBounds(boundsX, boundsY, boundsWidth, boundsHeight);
     label->setFont(Font("Small Text", 12, Font::plain));
     label->setColour(Label::textColourId, Colours::darkgrey);
-    addAndMakeVisible(label);
+    parent->addAndMakeVisible(label);
     return label;
 }
 
@@ -87,15 +320,56 @@ Label *RiverOutputEditor::newInputLabel(
         int boundsX,
         int boundsY,
         int boundsWidth,
-        int boundsHeight) {
+        int boundsHeight,
+        Component *parent) {
     auto *label = new Label(componentName, "");
     label->setBounds(boundsX, boundsY, boundsWidth, boundsHeight);
     label->setFont(Font("Default", 15, Font::plain));
     label->setColour(Label::textColourId, Colours::white);
     label->setColour(Label::backgroundColourId, Colours::grey);
     label->setEditable(true);
-    label->addListener(this);
+    label->addListener((Label::Listener *) parent);
     label->setTooltip(tooltip);
-    addAndMakeVisible(label);
+    parent->addAndMakeVisible(label);
     return label;
 }
+
+RiverOutputCanvas::RiverOutputCanvas(GenericProcessor *n) : processor(n) {
+    editor = dynamic_cast<RiverOutputEditor *>(processor->editor.get());
+    viewport = new Viewport();
+    Component *optionsPanel = editor->getOptionsPanel();
+    viewport->setViewedComponent(optionsPanel, false);
+    viewport->setScrollBarsShown(true, true);
+    addAndMakeVisible(viewport);
+
+    // Just updating the # of samples written, so can update pretty slow
+    refreshRate = 4;
+}
+
+void RiverOutputCanvas::refreshState() {}
+void RiverOutputCanvas::update() {}
+
+void RiverOutputCanvas::refresh() {
+    editor->refreshLabelsFromProcessor();
+    editor->repaint();
+}
+
+void RiverOutputCanvas::beginAnimation() {
+    startCallbacks();
+}
+void RiverOutputCanvas::endAnimation() {
+    stopCallbacks();
+}
+
+void RiverOutputCanvas::setParameter(int, float) {}
+void RiverOutputCanvas::setParameter(int, int, int, float) {}
+
+void RiverOutputCanvas::paint(Graphics &g) {
+    ColourGradient editorBg = editor->getBackgroundGradient();
+    g.fillAll(editorBg.getColourAtPosition(0.5)); // roughly matches editor background (without gradient)
+}
+
+void RiverOutputCanvas::resized() {
+    viewport->setBounds(0, 0, getWidth(), getHeight());
+}
+

--- a/Plugins/RiverOutput/RiverOutputEditor.h
+++ b/Plugins/RiverOutput/RiverOutputEditor.h
@@ -26,9 +26,15 @@
 
 
 #include <EditorHeaders.h>
+#include <VisualizerEditorHeaders.h>
+#include <VisualizerWindowHeaders.h>
 #include "RiverOutput.h"
+#include "SchemaListBox.h"
 
 class ImageIcon;
+
+class RiverOutputCanvas;
+
 
 /**
 
@@ -36,38 +42,69 @@ class ImageIcon;
 
   @see RiverOutput
 */
-
-class RiverOutputEditor : public GenericEditor,
-                          public Label::Listener {
+class RiverOutputEditor : public VisualizerEditor,
+                          public Label::Listener,
+                          public ComboBox::Listener {
 public:
     RiverOutputEditor(GenericProcessor *parentNode, bool useDefaultParameterEditors);
 
     ~RiverOutputEditor() override = default;
 
-    void labelTextChanged(Label* label) override;
+    Visualizer* createNewCanvas() override;
 
-    void refreshLabels();
+    // UI listeners
+    void labelTextChanged(Label* label) override;
+    void comboBoxChanged(ComboBox *comboBoxThatHasChanged) override;
+    void buttonEvent(Button* button) override;
+
+    // Non-overrides:
+    void refreshLabelsFromProcessor();
+    void refreshSchemaFromProcessor();
+
+    Component *getOptionsPanel() {
+        return optionsPanel.get();
+    }
 
 private:
     ImageIcon* icon;
+
+    void updateProcessorSchema();
 
     Label *newStaticLabel(
             const std::string& labelText,
             int boundsX,
             int boundsY,
             int boundsWidth,
-            int boundsHeight);
+            int boundsHeight) {
+        return newStaticLabel(labelText, boundsX, boundsY, boundsWidth, boundsHeight, this);
+    }
 
-    Label *newInputLabel(
-            const std::string& componentName,
-            const std::string& tooltip,
+    static Label *newStaticLabel(
+            const std::string& labelText,
             int boundsX,
             int boundsY,
             int boundsWidth,
-            int boundsHeight);
+            int boundsHeight,
+            Component *parent);
 
-    ScopedPointer<Label> streamNameLabel;
-    ScopedPointer<Label> streamNameLabelValue;
+    Label *newInputLabel(
+            const std::string &componentName,
+            const std::string &tooltip,
+            int boundsX,
+            int boundsY,
+            int boundsWidth,
+            int boundsHeight) {
+        return newInputLabel(componentName, tooltip, boundsX, boundsY, boundsWidth, boundsHeight, this);
+    }
+
+    static Label *newInputLabel(
+            const std::string &componentName,
+            const std::string &tooltip,
+            int boundsX,
+            int boundsY,
+            int boundsWidth,
+            int boundsHeight,
+            Component *parent);
 
     ScopedPointer<Label> hostnameLabel;
     ScopedPointer<Label> hostnameLabelValue;
@@ -79,10 +116,58 @@ private:
     ScopedPointer<Label> passwordLabel;
     ScopedPointer<Label> passwordLabelValue;
 
+    // OPTIONS PANEL
+    RiverOutputCanvas* canvas;
+    ScopedPointer<Component> optionsPanel;
+    ScopedPointer<Label> optionsPanelTitle;
+    ScopedPointer<Label> inputTypeTitle;
+
+    ScopedPointer<Label> streamNameLabel;
+    ScopedPointer<Label> streamNameLabelValue;
+
+    ScopedPointer<Label> totalSamplesWrittenLabel;
+    ScopedPointer<Label> totalSamplesWrittenLabelValue;
+
+    // OPTIONS PANEL: Input Type
+    const int inputTypeRadioId = 1;
+    ScopedPointer<ToggleButton> inputTypeSpikeButton;
+    ScopedPointer<ToggleButton> inputTypeEventButton;
+
+    ScopedPointer<Label> fieldNameLabel;
+    ScopedPointer<Label> fieldNameLabelValue;
+
+    ScopedPointer<Label> fieldTypeLabel;
+    ScopedPointer<ComboBox> fieldTypeComboBox;
+
+    ScopedPointer<UtilityButton> addFieldButton;
+    ScopedPointer<UtilityButton> removeSelectedFieldButton;
+
+    ScopedPointer<SchemaListBox> schemaList;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RiverOutputEditor)
 };
 
+class RiverOutputCanvas : public Visualizer {
+public:
+    explicit RiverOutputCanvas(GenericProcessor *n);
+    ~RiverOutputCanvas() override = default;
 
+    void refreshState() override;
+    void update() override;
+    void refresh() override;
+    void beginAnimation() override;
+    void endAnimation() override;
+    void setParameter(int, float) override;
+    void setParameter(int, int, int, float) override;
+    void paint(Graphics& g) override;
+    void resized() override;
+
+private:
+    ScopedPointer<Viewport> viewport;
+    GenericProcessor* processor;
+    RiverOutputEditor* editor;
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RiverOutputCanvas)
+};
 
 
 #endif  // __RIVEROUTPUTEDITOR_H_28EB4CC9__

--- a/Plugins/RiverOutput/SchemaListBox.h
+++ b/Plugins/RiverOutput/SchemaListBox.h
@@ -1,0 +1,100 @@
+//
+// Created by Paul Botros on 9/18/20.
+//
+
+#ifndef OPEN_EPHYS_GUI_SCHEMALISTBOX_H
+#define OPEN_EPHYS_GUI_SCHEMALISTBOX_H
+
+#include <VisualizerEditorHeaders.h>
+#include <VisualizerWindowHeaders.h>
+#include <EditorHeaders.h>
+#include <river/river.h>
+#include <sstream>
+
+class SchemaListBox : public Component, public ListBoxModel {
+public:
+    SchemaListBox() {
+        box.setModel(this);
+        box.setColour(ListBox::backgroundColourId, Colour::greyLevel(0.2f));
+        box.setRowHeight(30);
+        addAndMakeVisible(box);
+    }
+
+    void paintListBoxItem(int rowNumber, Graphics &g, int width, int height,
+                          bool rowIsSelected) override {
+        if (!isPositiveAndBelow(rowNumber, (int) fieldDefinitions_.size())) {
+            return;
+        }
+        g.fillAll(Colour::greyLevel(rowIsSelected ? 0.15f : 0.05f));
+        g.setFont(18);
+        g.setColour(Colours::whitesmoke);
+
+        auto field_def = fieldDefinitions_[rowNumber];
+
+        std::stringstream ss;
+        ss << field_def.name << " [";
+        switch (field_def.type) {
+            case river::FieldDefinition::DOUBLE:
+                ss << "DOUBLE";
+                break;
+            case river::FieldDefinition::FLOAT:
+                ss << "FLOAT";
+                break;
+            case river::FieldDefinition::INT32:
+                ss << "INT32";
+                break;
+            case river::FieldDefinition::INT64:
+                ss << "INT64";
+                break;
+            case river::FieldDefinition::FIXED_WIDTH_BYTES:
+            case river::FieldDefinition::VARIABLE_WIDTH_BYTES:
+            default:
+                ss << "UNKNOWN";
+                break;
+        }
+        ss << "]";
+
+        g.drawFittedText(String(ss.str()), {6, 0, width - 12, height}, Justification::centredLeft, 1, 1.f);
+    }
+
+    int getNumRows() override {
+        return fieldDefinitions_.size();
+    }
+
+    void removeSelectedRow() {
+        if (box.getSelectedRow(0) >= 0) {
+            fieldDefinitions_.erase(fieldDefinitions_.begin() + box.getSelectedRow(0));
+            box.updateContent();
+        }
+    }
+
+    void clearItems() {
+        fieldDefinitions_.clear();
+        box.updateContent();
+    }
+
+    void addItem(const river::FieldDefinition &fieldDefinition) {
+        fieldDefinitions_.push_back(fieldDefinition);
+        box.updateContent();
+        box.selectRow(fieldDefinitions_.size() - 1);
+    }
+
+    void resized() override {
+        box.setBounds(getLocalBounds());
+    }
+
+    const std::vector<river::FieldDefinition> &fieldDefinitions() {
+        return fieldDefinitions_;
+    }
+
+private:
+    ListBox box;
+    std::vector<river::FieldDefinition> fieldDefinitions_;
+};
+
+#include <EditorHeaders.h>
+#include <VisualizerEditorHeaders.h>
+#include <VisualizerWindowHeaders.h>
+#include "RiverOutput.h"
+
+#endif //OPEN_EPHYS_GUI_SCHEMALISTBOX_H


### PR DESCRIPTION
Adding ability to configure a custom schema based on binary events in
RiverOutput. Use the visualizer to configure the schema, and this node
will consume any (binary) events incoming and forward them to River.
![Open_Ephys_GUI_and_open-ephys-GUI_–_SchemaListBox_h](https://user-images.githubusercontent.com/773285/93622423-fab59600-f991-11ea-8034-b47787fe7722.png)
