### PR TITLE
Adding data/recording directories to the HTTP API

### DIFF
--- a/Plugins/RiverOutput/RiverOutput.cpp
+++ b/Plugins/RiverOutput/RiverOutput.cpp
@@ -141,7 +141,9 @@ bool RiverOutput::disable() {
 
 
 void RiverOutput::process(AudioSampleBuffer &buffer) {
-    checkForEvents(shouldConsumeSpikes());
+    if (writer_) {
+        checkForEvents(shouldConsumeSpikes());
+    }
 }
 
 std::string RiverOutput::streamName() const {

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -103,6 +103,11 @@ namespace CoreServices
 		return getProcessorGraph()->getGlobalSampleRate(true);
 	}
 
+    String getRecordingDirectory()
+    {
+        return getControlPanel()->getRecordingDirectory();
+    }
+
 	void setRecordingDirectory(String dir)
 	{
 		getControlPanel()->setRecordingDirectory(dir);

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -78,6 +78,9 @@ PLUGIN_API juce::int64 getSoftwareTimestamp();
 /** Gets the ticker frequency of the software timestamp clock*/
 PLUGIN_API float getSoftwareSampleRate();
 
+/** Retrieves the current recording directory */
+PLUGIN_API String getRecordingDirectory();
+
 /** Set new recording directory */
 PLUGIN_API void setRecordingDirectory(String dir);
 

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -754,7 +754,7 @@ AudioNode* ProcessorGraph::getAudioNode()
 
 }
 
-RecordNode* ProcessorGraph::getRecordNode()
+RecordNode* ProcessorGraph::getRecordNode() const
 {
 
     Node* node = getNodeForId(RECORD_NODE_ID);

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.h
@@ -71,7 +71,7 @@ public:
     void enableHttpServer();
     void disableHttpServer();
 
-    RecordNode* getRecordNode();
+    RecordNode* getRecordNode() const;
     AudioNode* getAudioNode();
     MessageCenter* getMessageCenter();
 

--- a/Source/UI/ControlPanel.cpp
+++ b/Source/UI/ControlPanel.cpp
@@ -494,6 +494,12 @@ bool ControlPanel::getRecordingState()
 
 }
 
+String ControlPanel::getRecordingDirectory()
+{
+    return filenameComponent->getCurrentFile().getFullPathName();
+}
+
+
 void ControlPanel::setRecordingDirectory(String path)
 {
     File newFile(path);

--- a/Source/UI/ControlPanel.h
+++ b/Source/UI/ControlPanel.h
@@ -308,6 +308,9 @@ public:
     /** Set recording directory and update FilenameComponent */
     void setRecordingDirectory(String path);
 
+    /** Gets the current recording directory */
+    String getRecordingDirectory();
+
     /** Return current acquisition state.*/
     bool getAcquisitionState();
 


### PR DESCRIPTION
Exposing data_parent_dir and data_dir (the user-specified directory and
the automatically generated per-session directory, respectively) via the
API. data_parent_dir should always be present and non-null, but data_dir
will only be populated once there has been a recording.