### PR TITLE
Clearing SpikeDisplay before each recording

### DIFF
--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
@@ -191,6 +191,12 @@ void SpikeDisplayCanvas::buttonClicked(Button* button)
     }
 }
 
+void SpikeDisplayCanvas::startRecording() {
+    // Ensure each recording session starts with a cleared display, otherwise pointers to stale spikes might exist
+    // in its buffers
+    spikeDisplay->clear();
+}
+
 void SpikeDisplayCanvas::saveVisualizerParameters(XmlElement* xml)
 {
 

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.h
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.h
@@ -95,7 +95,8 @@ public:
 
     void buttonClicked(Button* button);
 
-    void startRecording() { } // unused
+    void startRecording();
+
     void stopRecording() { } // unused
 
     SpikeDisplayNode* processor;


### PR DESCRIPTION
Was getting crashes with "garbage" spikes in the buffer when recording a second time in an existing instance.